### PR TITLE
Add support for Memory Bank Controllers

### DIFF
--- a/sharpboy/Memory.fs
+++ b/sharpboy/Memory.fs
@@ -192,7 +192,14 @@ let writeAddress16_2_2 (addressFirst:byte, addressSecond:byte, dataFirst:byte, d
 
 // Same for reading, much simpler
 let readAddress (address:uint16) = 
-    memory.[int address]
+    if mbcType = Mbc.RomOnly then 
+        memory.[int address] 
+    else
+        match address with
+        | address when address <= (snd ROM0) -> memory.[int address] 
+        | address when address >= (fst ROM1) && address <= (snd ROM1) -> rom.[int romBankOffset + (int address &&& int 0x3FFF)] 
+        | address when address >= (fst SWRAMBANK) && address <= (snd SWRAMBANK) -> rom.[int ramBankOffset + (int address &&& int 0x1FFF)] 
+        | _ -> memory.[int address] 
 
 let readAddress_2 (msb:byte, lsb: byte) = readAddress((uint16 msb <<< 8) ||| uint16 lsb)
 let readAddress16 (address:uint16) = uint16 (readAddress(address+1us)) <<< 8 ||| uint16 (readAddress(address))

--- a/sharpboy/Memory.fs
+++ b/sharpboy/Memory.fs
@@ -58,7 +58,6 @@ type Cartridge = | RomOnly = 0uy
 
 let mutable cartridge = Cartridge.RomOnly
 
-
 let mutable externalRamEnabled = false
 
 type Mbc = | RomOnly = 0
@@ -131,8 +130,6 @@ let  writeAddress (address:uint16, data:byte) =
                                                      rom.[int address + int ramBankOffset] <- data
                                                   if not hasExternalRam then 
                                                      memory.[int address] <- data
-                                                  //if hasExternalRam && hasBattery then //TODO:
-                                                     //File.WriteAllBytes("test.sav", rom.[int (fst SWRAMBANK)..(int (snd SWRAMBANK)])
                                                
     | address when address = P1 -> match ((data &&& 0b110000uy) >>> 4) with //bits 4 (P14 out port) & 5 (P15 out port)
                                    | 0b00uy -> memory.[int address] <- P14 &&& P15
@@ -155,14 +152,13 @@ let  writeAddress (address:uint16, data:byte) =
                                         memory.[int oamAddress] <- memory.[int dmaAddress]
                                         dmaAddress <- dmaAddress+1us
     | address when address = DIV -> memory.[int address] <- 0uy
-    | address when address = BGP -> memory.[int address] <- data //TODO: BGP
-    | address when address = OBP0 -> memory.[int address] <- data //TODO: OBP0
-    | address when address = OBP1 -> memory.[int address] <- data //TODO: OBP1
+    | address when address = BGP -> memory.[int address] <- data
+    | address when address = OBP0 -> memory.[int address] <- data
+    | address when address = OBP1 -> memory.[int address] <- data
     | address when address = LCDC -> if (data >>> 7) <> (memory.[int address] >>> 7) then
                                         lcdCycles <- 0
                                         memory.[int LY] <- 0uy
-                                        //if memory.[int LYC] = memory.[int LY] then memory.[int STAT] <- memory.[int STAT] ||| 0b100uy else memory.[int STAT] <- memory.[int STAT] &&& ~~~(0b100uy)
-                                        //memory.[int STAT] <- (memory.[int STAT] &&& 0xFCuy) ||| 0b10uy //->OAM
+
                                      memory.[int address] <- data
                                      BG_TILE_MAP_SEL <- if data &&& (1uy <<< 3) = 0uy then BG_TILE_MAP_0 else BG_TILE_MAP_1 
                                      TILE_PATTERN_TABLE_SEL <- if data &&& (1uy <<< 4) > 0uy then TILE_PATTERN_TABLE_0 else TILE_PATTERN_TABLE_1 

--- a/sharpboy/Memory.fs
+++ b/sharpboy/Memory.fs
@@ -5,7 +5,8 @@ let memory = Array.create (0xFFFF+1) 0uy
 let mutable temp = 0uy
 let mutable temp16 = 0us
 let mutable swap = 0
-
+//Initializing rom to be able to define readAdress before loading the rom from dialog box
+let mutable rom = [|0uy|]
 
 // Keep track of different memory places
 let ROM0 = (0us, 0x3FFFus) // ROM 0 (16 KB)
@@ -14,6 +15,7 @@ let VRAM = (0x8000us,0x9FFFus) // Video RAM (8KB)
 let IRAM = (0xC000us,0xDFFFus) // Interal RAM (8KB)
 let ECHO = (0xE000us,0xFDFFus) // Echo of internal RAM
 let OAM = (0xFE00us, 0xFE9Fus) // Object attribute memory
+let SWRAMBANK = (0xA000us,0xBFFFus) // Switchable RAM
 
 let mutable P14, P15 = 0xEFuy,0xDFuy //Joypad out ports
 

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -12,6 +12,19 @@ type DoubleBufferForm() =
     inherit Form()
     do base.SetStyle(ControlStyles.AllPaintingInWmPaint ||| ControlStyles.UserPaint ||| ControlStyles.DoubleBuffer, true)
 
+type Cartridge = | RomOnly = 0uy
+                     | Mbc1 = 1uy | Mbc1Ram = 2uy | Mbc1RamBatt = 3uy
+                     | Mbc2 = 5uy | RomMbc2Batt = 6uy
+                     | RomRam = 0x8uy | RomRamBatt = 0x9uy
+                     | RomMbc3TimerBatt = 0xFuy | RomMbc3TimerRamBatt = 0x10uy | RomMbc3 = 0x11uy
+                     | RomMbc3Ram = 0x12uy | RomMbc3RamBatt = 0x13uy
+
+type Mbc = | RomOnly = 0
+           | Mbc1 = 1 
+           | Mbc2 = 2 
+           | Mbc3 = 3 
+           | Mbc5 = 5
+
 [<EntryPoint>][<STAThread>]
 let main argv = 
 

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -90,9 +90,9 @@ let main argv =
         while true do
             if not stopped then
 
-                cycles <- opcode.[int (readAddress(PC))]() * 4uy
+                cycles <- opcode.[int (Memory.readAddress(PC))]() * 4uy
                 if cycles = 0uy then do
-                    ignore(MessageBox.Show(String.Format("Invalid Opcode {2}{0:X2} at 0x{1:X4}", readAddress(PC), (if unhandledCBOpcode then PC-1us else PC), if unhandledCBOpcode then "CB " else String.Empty))); 
+                    ignore(MessageBox.Show(String.Format("Invalid Opcode {2}{0:X2} at 0x{1:X4}", Memory.readAddress(PC), (if unhandledCBOpcode then PC-1us else PC), if unhandledCBOpcode then "CB " else String.Empty))); 
                     Environment.Exit(1)
             
                 lcdCycles <- lcdCycles + int cycles
@@ -122,9 +122,9 @@ let main argv =
                             let tileOffset = (uint16 ((x + int (memory.[int SCROLLX]))/8) + uint16 (32*((y+int (memory.[int SCROLLY]))/8))) % 0x400us
                             let tilePixelX = uint16 ((x+int (memory.[int SCROLLX]))%8)
                             let tilePixelY = uint16 ((y+int (memory.[int SCROLLY]))%8)
-                            let tileIndex = readAddress(BG_TILE_MAP_SEL + tileOffset)
+                            let tileIndex = Memory.readAddress(BG_TILE_MAP_SEL + tileOffset)
                             let address = TILE_PATTERN_TABLE_SEL + uint16 (if TILE_PATTERN_TABLE_SEL = TILE_PATTERN_TABLE_1 then (0x800s + ((int16 (sbyte tileIndex)) * 16s)) else (int16 tileIndex*16s)) + (tilePixelY*2us)
-                            screenBuffer.[(y*SCREEN_WIDTH) + x] <- (if readAddress(address) &&& (0b10000000uy >>> int tilePixelX) > 0uy then 1 else 0) ||| (if readAddress(address+1us) &&& (0b10000000uy >>> int tilePixelX) > 0uy then 0b10 else 0)
+                            screenBuffer.[(y*SCREEN_WIDTH) + x] <- (if Memory.readAddress(address) &&& (0b10000000uy >>> int tilePixelX) > 0uy then 1 else 0) ||| (if Memory.readAddress(address+1us) &&& (0b10000000uy >>> int tilePixelX) > 0uy then 0b10 else 0)
                     
                         for sprite in [(int (fst OAM))..4..(int (snd OAM))] do
                             let spx,spy,pattern,flipx,flipy = int memory.[sprite+1], int memory.[sprite], int memory.[sprite+2], int (if (memory.[sprite+3] &&& (1uy <<< 5)) > 0uy then 1uy else 0uy), int (if (memory.[sprite+3] &&& (1uy <<< 6)) > 0uy then 1uy else 0uy) 
@@ -132,7 +132,7 @@ let main argv =
                                 for tilePixelX in [0..7] do
                                     let ftilePixelX = if flipx = 1 then 7-tilePixelX else tilePixelX
                                     let address = TILE_PATTERN_TABLE_0 + uint16 ((pattern*16) + ((if flipy = 1 then (7-(y-(spy-16))) else y-(spy-16))*2))
-                                    let color = (if readAddress(address) &&& (0b10000000uy >>> ftilePixelX) > 0uy then 1 else 0) ||| (if readAddress(address+1us) &&& (0b10000000uy >>> ftilePixelX) > 0uy then 0b10 else 0)
+                                    let color = (if Memory.readAddress(address) &&& (0b10000000uy >>> ftilePixelX) > 0uy then 1 else 0) ||| (if Memory.readAddress(address+1us) &&& (0b10000000uy >>> ftilePixelX) > 0uy then 0b10 else 0)
                                     if color > 0 then screenBuffer.[(y*SCREEN_WIDTH) + spx - 8 + tilePixelX] <- color
                                      
                     incrementLY()

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -12,18 +12,6 @@ type DoubleBufferForm() =
     inherit Form()
     do base.SetStyle(ControlStyles.AllPaintingInWmPaint ||| ControlStyles.UserPaint ||| ControlStyles.DoubleBuffer, true)
 
-type Cartridge = | RomOnly = 0uy
-                 | Mbc1 = 1uy | Mbc1Ram = 2uy | Mbc1RamBatt = 3uy
-                 | Mbc2 = 5uy | Mbc2Batt = 6uy
-                 | RomRam = 0x8uy | RomRamBatt = 0x9uy
-                 | Mbc3TimerBatt = 0xFuy | Mbc3TimerRamBatt = 0x10uy | Mbc3 = 0x11uy
-                 | Mbc3Ram = 0x12uy | Mbc3RamBatt = 0x13uy
-
-type Mbc = | RomOnly = 0
-           | Mbc1 = 1 
-           | Mbc2 = 2 
-           | Mbc3 = 3 
-
 [<EntryPoint>][<STAThread>]
 let main argv = 
 
@@ -44,13 +32,18 @@ let main argv =
     else
         rom.CopyTo(memory,0)
 
-    let cartridge = LanguagePrimitives.EnumOfValue<byte, Cartridge>(memory.[0x0147])
-
+    //Reading bytes to know MBC type and cartridge options
+    Memory.cartridge <- LanguagePrimitives.EnumOfValue<byte, Memory.Cartridge>(memory.[0x0147])
+    
     let mbcType = match cartridge with
-                  | Cartridge.Mbc1 | Cartridge.Mbc1Ram | Cartridge.Mbc1RamBatt -> Mbc.Mbc1
-                  | Cartridge.Mbc2 | Cartridge.Mbc2Batt -> Mbc.Mbc2
-                  | Cartridge.Mbc3 | Cartridge.Mbc3Ram | Cartridge.Mbc3RamBatt | Cartridge.Mbc3TimerBatt | Cartridge.Mbc3TimerRamBatt -> Mbc.Mbc3
-                  | _ -> Mbc.RomOnly
+                | Memory.Cartridge.Mbc1 | Memory.Cartridge.Mbc1Ram | Memory.Cartridge.Mbc1RamBatt -> Mbc.Mbc1
+                | Memory.Cartridge.Mbc2 | Memory.Cartridge.Mbc2Batt -> Mbc.Mbc2
+                | Memory.Cartridge.Mbc3 | Memory.Cartridge.Mbc3Ram | Memory.Cartridge.Mbc3RamBatt | Memory.Cartridge.Mbc3TimerBatt | Memory.Cartridge.Mbc3TimerRamBatt -> Mbc.Mbc3
+                | _ -> Mbc.RomOnly
+
+    let hasExternalRam = match cartridge with
+                     | Memory.Cartridge.Mbc1Ram | Memory.Cartridge.Mbc1RamBatt | Memory.Cartridge.RomRam | Memory.Cartridge.RomRamBatt | Memory.Cartridge.Mbc3TimerRamBatt | Memory.Cartridge.Mbc3Ram | Memory.Cartridge.Mbc3RamBatt -> true
+                     | _ -> false
 
     let form = new DoubleBufferForm()
 

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -24,7 +24,7 @@ let main argv =
     openRomDialog.Title <- "Select Game Boy ROM" 
     openRomDialog.Filter <- "Gameboy ROM Files|*.gb|All files|*.*"
     if openRomDialog.ShowDialog() = DialogResult.OK then
-        rom <- File.ReadAllBytes(openRomDialog.FileName)
+        Memory.rom <- File.ReadAllBytes(openRomDialog.FileName)
     else Environment.Exit(1)
 
     if rom.Length > int (snd ROM1+1us) then

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -13,17 +13,16 @@ type DoubleBufferForm() =
     do base.SetStyle(ControlStyles.AllPaintingInWmPaint ||| ControlStyles.UserPaint ||| ControlStyles.DoubleBuffer, true)
 
 type Cartridge = | RomOnly = 0uy
-                     | Mbc1 = 1uy | Mbc1Ram = 2uy | Mbc1RamBatt = 3uy
-                     | Mbc2 = 5uy | RomMbc2Batt = 6uy
-                     | RomRam = 0x8uy | RomRamBatt = 0x9uy
-                     | RomMbc3TimerBatt = 0xFuy | RomMbc3TimerRamBatt = 0x10uy | RomMbc3 = 0x11uy
-                     | RomMbc3Ram = 0x12uy | RomMbc3RamBatt = 0x13uy
+                 | Mbc1 = 1uy | Mbc1Ram = 2uy | Mbc1RamBatt = 3uy
+                 | Mbc2 = 5uy | Mbc2Batt = 6uy
+                 | RomRam = 0x8uy | RomRamBatt = 0x9uy
+                 | Mbc3TimerBatt = 0xFuy | Mbc3TimerRamBatt = 0x10uy | Mbc3 = 0x11uy
+                 | Mbc3Ram = 0x12uy | Mbc3RamBatt = 0x13uy
 
 type Mbc = | RomOnly = 0
            | Mbc1 = 1 
            | Mbc2 = 2 
            | Mbc3 = 3 
-           | Mbc5 = 5
 
 [<EntryPoint>][<STAThread>]
 let main argv = 
@@ -44,6 +43,14 @@ let main argv =
         rom.[0..int (snd ROM1)].CopyTo(memory,0)
     else
         rom.CopyTo(memory,0)
+
+    let cartridge = LanguagePrimitives.EnumOfValue<byte, Cartridge>(memory.[0x0147])
+
+    let mbcType = match cartridge with
+                  | Cartridge.Mbc1 | Cartridge.Mbc1Ram | Cartridge.Mbc1RamBatt -> Mbc.Mbc1
+                  | Cartridge.Mbc2 | Cartridge.Mbc2Batt -> Mbc.Mbc2
+                  | Cartridge.Mbc3 | Cartridge.Mbc3Ram | Cartridge.Mbc3RamBatt | Cartridge.Mbc3TimerBatt | Cartridge.Mbc3TimerRamBatt -> Mbc.Mbc3
+                  | _ -> Mbc.RomOnly
 
     let form = new DoubleBufferForm()
 

--- a/sharpboy/Program.fs
+++ b/sharpboy/Program.fs
@@ -19,7 +19,6 @@ let main argv =
     memory.[int SCROLLY] <- 0x0uy  ; memory.[int LY] <-   0x0uy            ; memory.[int LYC] <-     0x0uy 
     memory.[int IE] <- 0x0uy  
 
-    let mutable rom = [|0uy|]
     let openRomDialog = new OpenFileDialog()
     openRomDialog.Title <- "Select Game Boy ROM" 
     openRomDialog.Filter <- "Gameboy ROM Files|*.gb|All files|*.*"
@@ -35,11 +34,11 @@ let main argv =
     //Reading bytes to know MBC type and cartridge options
     Memory.cartridge <- LanguagePrimitives.EnumOfValue<byte, Memory.Cartridge>(memory.[0x0147])
     
-    let mbcType = match cartridge with
-                | Memory.Cartridge.Mbc1 | Memory.Cartridge.Mbc1Ram | Memory.Cartridge.Mbc1RamBatt -> Mbc.Mbc1
-                | Memory.Cartridge.Mbc2 | Memory.Cartridge.Mbc2Batt -> Mbc.Mbc2
-                | Memory.Cartridge.Mbc3 | Memory.Cartridge.Mbc3Ram | Memory.Cartridge.Mbc3RamBatt | Memory.Cartridge.Mbc3TimerBatt | Memory.Cartridge.Mbc3TimerRamBatt -> Mbc.Mbc3
-                | _ -> Mbc.RomOnly
+    Memory.mbcType <- match cartridge with
+                      | Memory.Cartridge.Mbc1 | Memory.Cartridge.Mbc1Ram | Memory.Cartridge.Mbc1RamBatt -> Memory.Mbc.Mbc1
+                      | Memory.Cartridge.Mbc2 | Memory.Cartridge.Mbc2Batt -> Memory.Mbc.Mbc2
+                      | Memory.Cartridge.Mbc3 | Memory.Cartridge.Mbc3Ram | Memory.Cartridge.Mbc3RamBatt | Memory.Cartridge.Mbc3TimerBatt | Memory.Cartridge.Mbc3TimerRamBatt -> Memory.Mbc.Mbc3
+                      | _ -> Memory.Mbc.RomOnly
 
     let hasExternalRam = match cartridge with
                      | Memory.Cartridge.Mbc1Ram | Memory.Cartridge.Mbc1RamBatt | Memory.Cartridge.RomRam | Memory.Cartridge.RomRamBatt | Memory.Cartridge.Mbc3TimerRamBatt | Memory.Cartridge.Mbc3Ram | Memory.Cartridge.Mbc3RamBatt -> true


### PR DESCRIPTION
This allows us to play the majority of games, which use additional hardware in the cartridge to map memory addresses.